### PR TITLE
Make candidate_id optional in Reviews API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [1.4.0] - 2025-06-24
+- Make candidate_id optional in Reviews API - allows fetching all reviews without filtering by candidate
+
 ## [1.3.0] - 2025-06-24
 - Adds support for feedback on reviews
 

--- a/lib/trakstar/api/reviews.rb
+++ b/lib/trakstar/api/reviews.rb
@@ -6,8 +6,9 @@ module Trakstar
   module Api
     class Reviews
       class << self
-        def all(candidate_id)
-          Http.get_all("/reviews", query_params: {candidate_id: candidate_id}).map do |data|
+        def all(candidate_id = nil)
+          query_params = candidate_id ? {candidate_id: candidate_id} : {}
+          Http.get_all("/reviews", query_params: query_params).map do |data|
             set!(Review.new, data)
           end
         end

--- a/lib/trakstar/version.rb
+++ b/lib/trakstar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Trakstar
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
- Allow fetching all reviews without filtering by candidate_id
- Bump version to 1.4.0
- Update CHANGELOG with new feature