### PR TITLE
Expand Opening object support to full API schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [2.1.4] - 2026-04-04
+- Add support for additional Opening object fields, including stage prospecting state, application form fields, and additional fields.
+
 ## [1.4.0] - 2025-06-24
 - Make candidate_id optional in Reviews API - allows fetching all reviews without filtering by candidate
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trakstar (2.1.3)
+    trakstar (2.1.4)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ Trakstar.openings
 Trakstar.opening(id)
 ```
 
+Opening objects expose fields from the Trakstar Hire Opening Object, including:
+
+- `api_id`, `title`, `description`, `team`, `state`
+- `position_type`, `is_remote_allowed`
+- `location` (string or object depending on API response)
+- `location_city`, `location_state`, `location_zipcode`, `location_country`
+- `private`, `is_private`
+- `hosted_url`, `application_email`, `is_archived`
+- `created_at`, `updated_at`, `close_date`
+- `tags`
+
+Nested opening data:
+
+- `stages`: array of stage objects (`api_id`, `name`, `type`, `is_prospecting`, `position`)
+- `application_form_fields`: array of application form field objects (`name`, `display_name`, `type`, `choices`, `is_required`, `is_disabled`, `position`)
+- `additional_fields`: array of additional field objects (`name`, `value`, `is_private`)
+
+Example:
+
+```ruby
+opening = Trakstar.opening(678305)
+
+opening.title
+opening.position_type
+opening.application_form_fields.first.display_name
+opening.stages.first.is_prospecting
+```
+
 ## Candidates
 
 ```ruby

--- a/lib/trakstar/api/openings.rb
+++ b/lib/trakstar/api/openings.rb
@@ -1,10 +1,25 @@
 module Trakstar
   class Opening < Models::Base
-    synced_attr_accessor :title, :state, :private, :tags, :stages
+    synced_attr_accessor :title, :description, :team, :state, :position_type,
+                         :is_remote_allowed, :location, :location_city,
+                         :location_state, :location_zipcode, :location_country,
+                         :private, :is_private, :hosted_url, :application_email,
+                         :is_archived, :created_at, :updated_at, :close_date,
+                         :tags, :stages, :application_form_fields,
+                         :additional_fields
   end
 
   class Stage < Models::Base
-    attr_accessor :position, :name, :type
+    attr_accessor :position, :name, :type, :is_prospecting
+  end
+
+  class ApplicationFormField < Models::Base
+    attr_accessor :name, :display_name, :type, :choices,
+                  :is_required, :is_disabled, :position
+  end
+
+  class AdditionalField < Models::Base
+    attr_accessor :name, :value, :is_private
   end
 
   module Api
@@ -29,12 +44,41 @@ module Trakstar
 
       def self.set!(opening, data)
         opening.tap do |opening|
-          opening.title = data["title"]
           opening.api_id = data["id"]
+          opening.title = data["title"]
+          opening.description = data["description"]
+          opening.team = data["team"]
           opening.state = data["state"]
-          opening.tags = data["tags"]
+          opening.position_type = data["position_type"]
+          opening.is_remote_allowed = data["is_remote_allowed"]
+
+          location_data = data["location"]
+          opening.location = location_data
+          if location_data.is_a?(Hash)
+            opening.location_city = location_data["city"]
+            opening.location_state = location_data["state"]
+            opening.location_zipcode = location_data["zipcode"]
+            opening.location_country = location_data["country"]
+          end
+
           opening.private = data["is_private"]
+          opening.is_private = data["is_private"]
+          opening.hosted_url = data["hosted_url"]
+          opening.application_email = data["application_email"]
+          opening.is_archived = data["is_archived"]
+          opening.created_at = data["created_date"]
+          opening.updated_at = data["modified_date"]
+          opening.close_date = data["close_date"]
+          opening.tags = data["tags"]
+
           opening.stages = build_stages(data["stages"]) if data.key?("stages")
+          if data.key?("application_form_fields")
+            opening.application_form_fields = build_application_form_fields(data["application_form_fields"])
+          end
+          if data.key?("additional_fields")
+            opening.additional_fields = build_additional_fields(data["additional_fields"])
+          end
+
           opening.sync = -> { sync(opening) }
         end
       end
@@ -45,7 +89,32 @@ module Trakstar
             stage.api_id = stage_data["id"]
             stage.name = stage_data["name"]
             stage.type = stage_data["type"]
+            stage.is_prospecting = stage_data["is_prospecting"]
             stage.position = stage_data["position"]
+          end
+        end
+      end
+
+      def self.build_application_form_fields(application_form_fields_data)
+        application_form_fields_data.map do |field_data|
+          ApplicationFormField.new.tap do |field|
+            field.name = field_data["name"]
+            field.display_name = field_data["display_name"]
+            field.type = field_data["type"]
+            field.choices = field_data["choices"]
+            field.is_required = field_data["is_required"]
+            field.is_disabled = field_data["is_disabled"]
+            field.position = field_data["position"]
+          end
+        end
+      end
+
+      def self.build_additional_fields(additional_fields_data)
+        additional_fields_data.map do |field_data|
+          AdditionalField.new.tap do |field|
+            field.name = field_data["name"]
+            field.value = field_data["value"]
+            field.is_private = field_data["is_private"]
           end
         end
       end

--- a/lib/trakstar/version.rb
+++ b/lib/trakstar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Trakstar
-  VERSION = "2.1.3"
+  VERSION = "2.1.4"
 end

--- a/test/system/openings_test.rb
+++ b/test/system/openings_test.rb
@@ -16,10 +16,40 @@ class OpeningsTest < Minitest::Test
       assert_equal 678305, staff_opening.api_id
       assert_equal "Wisconsin", staff_opening.state
       assert_equal false, staff_opening.private
+      assert_equal false, staff_opening.is_private
+      assert_equal "Object-based composite model", staff_opening.description
+      assert_equal "Maine", staff_opening.location
+      assert_equal "Full Time", staff_opening.position_type
+      assert_equal true, staff_opening.is_remote_allowed
+      assert_equal "berna_dietrich@huels.example", staff_opening.application_email
+      assert_equal "http://batz.example/carrol_roberts", staff_opening.hosted_url
+      assert_equal false, staff_opening.is_archived
+      assert_equal "2025-01-15", staff_opening.created_at
+      assert_equal "2025-09-11", staff_opening.updated_at
+      assert_equal "2025-07-18", staff_opening.close_date
+      assert_equal "typewriter", staff_opening.team
+
+      assert_equal 2, staff_opening.additional_fields.count
+      additional_field = staff_opening.additional_fields.first
+      assert_equal "fugiat", additional_field.name
+      assert_equal "consequatur", additional_field.value
+      assert_equal true, additional_field.is_private
 
       assert_equal 14, staff_opening.stages.count
+      assert_equal "Public Relations and Communications", staff_opening.title
       stage = staff_opening.stages.first
       assert_equal 5986001, stage.api_id
+      assert_equal "quis", stage.name
+      assert_equal false, stage.is_prospecting
+
+      assert_equal 16, staff_opening.application_form_fields.count
+      application_form_field = staff_opening.application_form_fields.first
+      assert_equal "sunt", application_form_field.name
+      assert_equal "hic", application_form_field.display_name
+      assert_equal "aliquam", application_form_field.type
+      assert_equal ["et", "dignissimos"], application_form_field.choices
+      assert_equal false, application_form_field.is_required
+      assert_equal false, application_form_field.is_disabled
     end
   end
 end


### PR DESCRIPTION
## Summary
- expand Opening model mapping to include additional fields from the Opening Object API
- add nested support for stage prospecting, application form fields, and additional fields
- document supported Opening fields in README
- bump gem version to 2.1.4 and add changelog entry

## Validation
- bundle exec ruby -Itest test/system/openings_test.rb